### PR TITLE
[WIP] add multiple context support for EKS clusters / AWS profiles

### DIFF
--- a/src/eks-mcp-server/README.md
+++ b/src/eks-mcp-server/README.md
@@ -262,7 +262,7 @@ Sets the logging level verbosity for the server.
 
 #### `AWS_PROFILE` (optional)
 
-Specifies the AWS profile to use for authentication.
+Specifies the AWS profile to use for authentication. **Note**: You can also dynamically switch profiles at runtime using the `set_aws_profile` tool without restarting the server.
 
 * Default: None (If not set, uses default AWS credentials).
 * Example: `"AWS_PROFILE": "my-profile"`
@@ -285,6 +285,72 @@ Configures proxy settings for HTTP and HTTPS connections. These environment vari
 ## Tools
 
 The following tools are provided by the EKS MCP server for managing Amazon EKS clusters and Kubernetes resources. Each tool performs a specific action that can be invoked to automate common tasks in your EKS clusters and Kubernetes workloads.
+
+### Multi-Profile and Multi-Context Management
+
+The EKS MCP server now supports dynamic AWS profile and Kubernetes context switching, enabling you to manage multiple EKS clusters across different AWS accounts without restarting the server. This is particularly useful for organizations managing large numbers of clusters (100+) across multiple AWS accounts.
+
+#### `list_aws_profiles`
+
+Lists all available AWS profiles from `~/.aws/config` and `~/.aws/credentials`.
+
+Features:
+
+* Reads AWS configuration files and returns all available profile names
+* Helps you see which profiles can be activated with `set_aws_profile`
+
+Returns: List of available AWS profile names
+
+#### `set_aws_profile`
+
+Sets the active AWS profile for all subsequent AWS operations.
+
+Features:
+
+* Dynamically switches AWS profiles without server restart
+* Clears cached AWS clients to ensure new profile is used
+* Validates that the profile exists before switching
+
+Parameters:
+
+* profile_name (required): Name of the AWS profile to activate
+
+#### `get_aws_profile`
+
+Gets the currently active AWS profile.
+
+Returns: Name of the current AWS profile or information about default credentials
+
+#### `list_k8s_contexts`
+
+Lists all available Kubernetes contexts from `~/.kube/config`.
+
+Features:
+
+* Reads kubeconfig file and returns all available context names
+* Helps you see which contexts can be activated with `set_k8s_context`
+
+Returns: List of available Kubernetes context names
+
+#### `set_k8s_context`
+
+Sets the active Kubernetes context for all subsequent Kubernetes operations.
+
+Features:
+
+* Dynamically switches Kubernetes contexts without server restart
+* Clears cached Kubernetes clients to ensure new context is used
+* Validates that the context exists before switching
+
+Parameters:
+
+* context_name (required): Name of the Kubernetes context to activate
+
+#### `get_k8s_context`
+
+Gets the currently active Kubernetes context.
+
+Returns: Name of the current Kubernetes context
 
 ### EKS Cluster Management
 

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/aws_helper.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/aws_helper.py
@@ -16,10 +16,11 @@
 
 import boto3
 import os
+from threading import RLock
 from awslabs.eks_mcp_server import __version__
 from botocore.config import Config
 from loguru import logger
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 
 class AwsHelper:
@@ -35,11 +36,14 @@ class AwsHelper:
     # Singleton instance
     _instance = None
 
-    # Client cache with AWS service name as key
-    _client_cache: Dict[str, Any] = {}
-    
+    # Client cache keyed by (service_name, region, profile)
+    _client_cache: Dict[Tuple[str, Optional[str], Optional[str]], Any] = {}
+
     # Active profile (overrides environment variable)
     _active_profile: Optional[str] = None
+
+    # Re-entrant lock to guard shared state
+    _lock: RLock = RLock()
 
     @staticmethod
     def get_aws_region() -> Optional[str]:
@@ -62,9 +66,10 @@ class AwsHelper:
         Args:
             profile_name: Name of the AWS profile to set, or None to use default
         """
-        cls._active_profile = profile_name
-        cls._client_cache.clear()
-        logger.info(f'Active AWS profile set to: {profile_name}')
+        with cls._lock:
+            cls._active_profile = profile_name
+            cls._client_cache.clear()
+        logger.debug(f'Active AWS profile set to: {profile_name!r}')
     
     @classmethod
     def get_active_profile(cls) -> Optional[str]:
@@ -76,7 +81,9 @@ class AwsHelper:
         Returns:
             Name of the active AWS profile, or None if using default credentials
         """
-        return cls._active_profile if cls._active_profile is not None else cls.get_aws_profile()
+        with cls._lock:
+            active_profile = cls._active_profile
+        return active_profile if active_profile is not None else cls.get_aws_profile()
 
     @classmethod
     def create_boto3_client(cls, service_name: str, region_name: Optional[str] = None) -> Any:
@@ -97,40 +104,43 @@ class AwsHelper:
             Exception: If there's an error creating the client
         """
         try:
-            # Get region from parameter or environment if set
-            region: Optional[str] = (
+            # Resolve region preference and active profile
+            resolved_region: Optional[str] = (
                 region_name if region_name is not None else cls.get_aws_region()
             )
-
-            # Get profile - use active profile if set, otherwise use environment variable
             profile = cls.get_active_profile()
 
-            # Use service name as the cache key
-            cache_key = service_name
+            cache_key = (service_name, resolved_region, profile)
 
-            # Check if client is already in cache
-            if cache_key in cls._client_cache:
-                logger.info(f'Using cached boto3 client for {service_name}')
-                return cls._client_cache[cache_key]
+            with cls._lock:
+                cached_client = cls._client_cache.get(cache_key)
+            if cached_client is not None:
+                logger.debug(
+                    'Using cached boto3 client for %s (region=%r, profile=%r)',
+                    service_name,
+                    resolved_region,
+                    profile,
+                )
+                return cached_client
 
             # Create config with user agent suffix
             config = Config(user_agent_extra=f'awslabs/mcp/eks-mcp-server/{__version__}')
 
-            # Create session with profile if specified
-            if profile:
-                session = boto3.Session(profile_name=profile)
-                if region is not None:
-                    client = session.client(service_name, region_name=region, config=config)
-                else:
-                    client = session.client(service_name, config=config)
-            else:
-                if region is not None:
-                    client = boto3.client(service_name, region_name=region, config=config)
-                else:
-                    client = boto3.client(service_name, config=config)
+            session_kwargs: Dict[str, Optional[str]] = {}
+            if profile is not None:
+                session_kwargs['profile_name'] = profile
+            if resolved_region is not None:
+                session_kwargs['region_name'] = resolved_region
 
-            # Cache the client
-            cls._client_cache[cache_key] = client
+            session = boto3.Session(**session_kwargs)
+            client_kwargs: Dict[str, Any] = {'config': config}
+            if resolved_region is not None:
+                client_kwargs['region_name'] = resolved_region
+
+            client = session.client(service_name, **client_kwargs)
+
+            with cls._lock:
+                cls._client_cache[cache_key] = client
 
             return client
         except Exception as e:

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/aws_helper.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/aws_helper.py
@@ -37,6 +37,9 @@ class AwsHelper:
 
     # Client cache with AWS service name as key
     _client_cache: Dict[str, Any] = {}
+    
+    # Active profile (overrides environment variable)
+    _active_profile: Optional[str] = None
 
     @staticmethod
     def get_aws_region() -> Optional[str]:
@@ -47,6 +50,33 @@ class AwsHelper:
     def get_aws_profile() -> Optional[str]:
         """Get the AWS profile from the environment if set."""
         return os.environ.get('AWS_PROFILE')
+    
+    @classmethod
+    def set_active_profile(cls, profile_name: Optional[str]) -> None:
+        """Set the active AWS profile and clear the client cache.
+        
+        This allows dynamic switching between AWS profiles at runtime.
+        Setting the profile clears all cached clients to ensure they
+        are recreated with the new profile.
+        
+        Args:
+            profile_name: Name of the AWS profile to set, or None to use default
+        """
+        cls._active_profile = profile_name
+        cls._client_cache.clear()
+        logger.info(f'Active AWS profile set to: {profile_name}')
+    
+    @classmethod
+    def get_active_profile(cls) -> Optional[str]:
+        """Get the currently active AWS profile.
+        
+        Returns the profile set via set_active_profile, or falls back to
+        the AWS_PROFILE environment variable.
+        
+        Returns:
+            Name of the active AWS profile, or None if using default credentials
+        """
+        return cls._active_profile if cls._active_profile is not None else cls.get_aws_profile()
 
     @classmethod
     def create_boto3_client(cls, service_name: str, region_name: Optional[str] = None) -> Any:
@@ -72,8 +102,8 @@ class AwsHelper:
                 region_name if region_name is not None else cls.get_aws_region()
             )
 
-            # Get profile from environment if set
-            profile = cls.get_aws_profile()
+            # Get profile - use active profile if set, otherwise use environment variable
+            profile = cls.get_active_profile()
 
             # Use service name as the cache key
             cache_key = service_name

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_client_cache.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_client_cache.py
@@ -16,9 +16,12 @@
 
 import base64
 import os
-import yaml
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from threading import RLock
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import yaml
 from awslabs.eks_mcp_server.aws_helper import AwsHelper
 from awslabs.eks_mcp_server.k8s_apis import K8sApis
 from cachetools import TTLCache
@@ -34,6 +37,18 @@ K8S_AWS_ID_HEADER = 'x-k8s-aws-id'
 TOKEN_TTL = 14 * 60
 
 
+class KubeconfigParseError(Exception):
+    """Raised when kubeconfig parsing fails."""
+
+
+@dataclass(frozen=True)
+class KubeconfigIndex:
+    """Indexed kubeconfig metadata for quick context lookup."""
+
+    signature: Tuple[Tuple[str, int], ...]
+    context_to_cluster: Dict[str, str]
+
+
 class K8sClientCache:
     """Singleton class for managing Kubernetes API client cache.
 
@@ -43,6 +58,7 @@ class K8sClientCache:
 
     # Singleton instance
     _instance = None
+    _lock: RLock = RLock()
 
     def __new__(cls):
         """Ensure only one instance of K8sClientCache exists."""
@@ -57,14 +73,17 @@ class K8sClientCache:
         if hasattr(self, '_initialized') and self._initialized:
             return
 
-        # Client cache with TTL to handle token expiration
-        self._client_cache = TTLCache(maxsize=100, ttl=TOKEN_TTL)
+        # Client cache with TTL to handle token expiration; keyed by (context, cluster)
+        self._client_cache: TTLCache = TTLCache(maxsize=100, ttl=TOKEN_TTL)
 
         # Flag to track if STS event handlers have been registered
         self._sts_event_handlers_registered = False
         
         # Active Kubernetes context (for kubeconfig-based contexts)
         self._active_context: Optional[str] = None
+
+        # Cached mapping of contexts to clusters with file signature tracking
+        self._kubeconfig_index: Optional[KubeconfigIndex] = None
 
         self._initialized = True
 
@@ -147,24 +166,38 @@ class K8sClientCache:
             ValueError: If the cluster credentials are invalid
             Exception: If there's an error getting the cluster credentials
         """
-        if cluster_name not in self._client_cache:
-            try:
-                # Create a new client
-                endpoint, token, ca_data = self._get_cluster_credentials(cluster_name)
+        cache_key = (self._active_context, cluster_name)
 
-                # Validate credentials
-                if not endpoint or not token or endpoint is None or token is None:
-                    raise ValueError('Invalid cluster credentials')
+        with self._lock:
+            cached_client = self._client_cache.get(cache_key)
+        if cached_client is not None:
+            logger.debug(
+                'Using cached Kubernetes client for cluster %s (context=%r)',
+                cluster_name,
+                self._active_context,
+            )
+            return cached_client
 
-                self._client_cache[cluster_name] = K8sApis(endpoint, token, ca_data)
-            except ValueError:
-                # Re-raise ValueError for invalid credentials
-                raise
-            except Exception as e:
-                # Re-raise any other exceptions
-                raise Exception(f'Failed to get cluster credentials: {str(e)}')
+        try:
+            # Create a new client
+            endpoint, token, ca_data = self._get_cluster_credentials(cluster_name)
 
-        return self._client_cache[cluster_name]
+            # Validate credentials
+            if not endpoint or not token or endpoint is None or token is None:
+                raise ValueError('Invalid cluster credentials')
+
+            new_client = K8sApis(endpoint, token, ca_data)
+        except ValueError:
+            # Re-raise ValueError for invalid credentials
+            raise
+        except Exception as e:
+            # Re-raise any other exceptions
+            raise Exception(f'Failed to get cluster credentials: {str(e)}')
+
+        with self._lock:
+            self._client_cache[cache_key] = new_client
+
+        return new_client
     
     def set_active_context(self, context_name: str) -> None:
         """Set the active Kubernetes context.
@@ -176,9 +209,15 @@ class K8sClientCache:
         Args:
             context_name: Name of the Kubernetes context to set
         """
-        self._active_context = context_name
-        self._client_cache.clear()
-        logger.info(f'Active Kubernetes context set to: {context_name}')
+        with self._lock:
+            self._active_context = context_name
+            keys_to_remove = [key for key in self._client_cache if key[0] == context_name]
+            for key in keys_to_remove:
+                try:
+                    del self._client_cache[key]
+                except KeyError:
+                    continue
+        logger.debug(f'Active Kubernetes context set to: {context_name!r}')
     
     def get_active_context(self) -> Optional[str]:
         """Get the currently active Kubernetes context.
@@ -186,7 +225,16 @@ class K8sClientCache:
         Returns:
             Name of the active context, or None if not set
         """
-        return self._active_context
+        with self._lock:
+            return self._active_context
+
+    def list_contexts(self) -> List[str]:
+        """List all known Kubernetes contexts from kubeconfig files."""
+        with self._lock:
+            index = self._ensure_kubeconfig_index()
+            if index is None:
+                return []
+            return list(index.context_to_cluster.keys())
     
     def get_cluster_from_context(self, context_name: Optional[str] = None) -> Optional[str]:
         """Get the cluster name associated with a Kubernetes context.
@@ -199,36 +247,94 @@ class K8sClientCache:
         Returns:
             Cluster name associated with the context, or None if not found
         """
-        if context_name is None:
-            context_name = self._active_context
-        
-        if context_name is None:
+        target_context = context_name
+        if target_context is None:
+            with self._lock:
+                target_context = self._active_context
+
+        if target_context is None:
             return None
-        
-        try:
-            kubeconfig_path = os.environ.get('KUBECONFIG', str(Path.home() / '.kube' / 'config'))
-            
-            if not Path(kubeconfig_path).exists():
-                logger.warning(f'Kubeconfig file not found at: {kubeconfig_path}')
+
+        with self._lock:
+            index = self._ensure_kubeconfig_index()
+            if index is None:
                 return None
-            
-            with open(kubeconfig_path, 'r') as f:
-                kubeconfig = yaml.safe_load(f)
-            
-            if not kubeconfig or 'contexts' not in kubeconfig:
-                return None
-            
-            # Find the context
-            for context in kubeconfig.get('contexts', []):
-                if context.get('name') == context_name:
-                    cluster_name = context.get('context', {}).get('cluster')
-                    if cluster_name:
-                        logger.info(f'Resolved context {context_name} to cluster: {cluster_name}')
-                        return cluster_name
-            
-            logger.warning(f'Context {context_name} not found in kubeconfig')
-            return None
-            
-        except Exception as e:
-            logger.error(f'Failed to read kubeconfig: {str(e)}')
-            return None
+            cluster_name = index.context_to_cluster.get(target_context)
+
+        if cluster_name:
+            logger.debug(
+                'Resolved context %s to cluster %s',
+                target_context,
+                cluster_name,
+            )
+            return cluster_name
+
+        logger.warning(
+            'Context %s not found in kubeconfig sources %s',
+            target_context,
+            self._kubeconfig_signature_repr(),
+        )
+        return None
+
+    def _kubeconfig_signature_repr(self) -> str:
+        with self._lock:
+            if self._kubeconfig_index is None:
+                return '[]'
+            return str([path for path, _ in self._kubeconfig_index.signature])
+
+    def _ensure_kubeconfig_index(self) -> Optional[KubeconfigIndex]:
+        paths = self._resolve_kubeconfig_paths()
+        signature = self._build_signature(paths)
+
+        if self._kubeconfig_index is not None and self._kubeconfig_index.signature == signature:
+            return self._kubeconfig_index
+
+        context_map: Dict[str, str] = {}
+
+        for path in paths:
+            if not path.exists():
+                logger.debug('Kubeconfig file %s does not exist; skipping', path)
+                continue
+
+            try:
+                with path.open('r', encoding='utf-8') as handle:
+                    kubeconfig = yaml.safe_load(handle) or {}
+            except yaml.YAMLError as exc:
+                raise KubeconfigParseError(str(exc)) from exc
+            except OSError as exc:
+                logger.warning('Unable to read kubeconfig %s: %s', path, exc)
+                continue
+
+            for context in kubeconfig.get('contexts', []) or []:
+                if not isinstance(context, dict):
+                    continue
+                name = context.get('name')
+                if not name:
+                    continue
+                cluster = (context.get('context') or {}).get('cluster')
+                if cluster:
+                    context_map[name] = cluster
+
+        self._kubeconfig_index = KubeconfigIndex(signature=signature, context_to_cluster=context_map)
+        return self._kubeconfig_index
+
+    @staticmethod
+    def _build_signature(paths: Iterable[Path]) -> Tuple[Tuple[str, int], ...]:
+        signature_entries: List[Tuple[str, int]] = []
+        for path in paths:
+            try:
+                mtime_ns = path.stat().st_mtime_ns
+            except FileNotFoundError:
+                mtime_ns = -1
+            signature_entries.append((str(path), mtime_ns))
+        return tuple(signature_entries)
+
+    @staticmethod
+    def _resolve_kubeconfig_paths() -> List[Path]:
+        raw_value = os.environ.get('KUBECONFIG')
+        if raw_value:
+            parts = [Path(part).expanduser() for part in raw_value.split(os.pathsep) if part]
+            if parts:
+                return parts
+        return [Path.home() / '.kube' / 'config']
+

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_client_cache.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_client_cache.py
@@ -15,9 +15,14 @@
 """Kubernetes client cache for the EKS MCP Server."""
 
 import base64
+import os
+import yaml
+from pathlib import Path
+from typing import Optional
 from awslabs.eks_mcp_server.aws_helper import AwsHelper
 from awslabs.eks_mcp_server.k8s_apis import K8sApis
 from cachetools import TTLCache
+from loguru import logger
 
 
 # Presigned url timeout in seconds
@@ -57,6 +62,9 @@ class K8sClientCache:
 
         # Flag to track if STS event handlers have been registered
         self._sts_event_handlers_registered = False
+        
+        # Active Kubernetes context (for kubeconfig-based contexts)
+        self._active_context: Optional[str] = None
 
         self._initialized = True
 
@@ -157,3 +165,70 @@ class K8sClientCache:
                 raise Exception(f'Failed to get cluster credentials: {str(e)}')
 
         return self._client_cache[cluster_name]
+    
+    def set_active_context(self, context_name: str) -> None:
+        """Set the active Kubernetes context.
+        
+        This allows dynamic switching between Kubernetes contexts at runtime.
+        Setting the context clears the client cache to ensure clients are
+        recreated with the new context.
+        
+        Args:
+            context_name: Name of the Kubernetes context to set
+        """
+        self._active_context = context_name
+        self._client_cache.clear()
+        logger.info(f'Active Kubernetes context set to: {context_name}')
+    
+    def get_active_context(self) -> Optional[str]:
+        """Get the currently active Kubernetes context.
+        
+        Returns:
+            Name of the active context, or None if not set
+        """
+        return self._active_context
+    
+    def get_cluster_from_context(self, context_name: Optional[str] = None) -> Optional[str]:
+        """Get the cluster name associated with a Kubernetes context.
+        
+        This reads the kubeconfig file to map a context to its cluster name.
+        
+        Args:
+            context_name: Name of the context, or None to use the active context
+            
+        Returns:
+            Cluster name associated with the context, or None if not found
+        """
+        if context_name is None:
+            context_name = self._active_context
+        
+        if context_name is None:
+            return None
+        
+        try:
+            kubeconfig_path = os.environ.get('KUBECONFIG', str(Path.home() / '.kube' / 'config'))
+            
+            if not Path(kubeconfig_path).exists():
+                logger.warning(f'Kubeconfig file not found at: {kubeconfig_path}')
+                return None
+            
+            with open(kubeconfig_path, 'r') as f:
+                kubeconfig = yaml.safe_load(f)
+            
+            if not kubeconfig or 'contexts' not in kubeconfig:
+                return None
+            
+            # Find the context
+            for context in kubeconfig.get('contexts', []):
+                if context.get('name') == context_name:
+                    cluster_name = context.get('context', {}).get('cluster')
+                    if cluster_name:
+                        logger.info(f'Resolved context {context_name} to cluster: {cluster_name}')
+                        return cluster_name
+            
+            logger.warning(f'Context {context_name} not found in kubeconfig')
+            return None
+            
+        except Exception as e:
+            logger.error(f'Failed to read kubeconfig: {str(e)}')
+            return None

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/k8s_handler.py
@@ -34,7 +34,7 @@ from awslabs.eks_mcp_server.models import (
 from mcp.server.fastmcp import Context
 from mcp.types import TextContent
 from pydantic import Field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 
 class K8sHandler:
@@ -71,6 +71,26 @@ class K8sHandler:
         self.mcp.tool(name='apply_yaml')(self.apply_yaml)
         self.mcp.tool(name='generate_app_manifest')(self.generate_app_manifest)
 
+    def _resolve_cluster_name(self, ctx: Context, cluster_name: Optional[str]) -> Tuple[str, Optional[str]]:
+        """Resolve the target cluster name, optionally using the active context."""
+        if cluster_name:
+            return cluster_name, None
+
+        resolved_cluster = self.client_cache.get_cluster_from_context()
+        active_context = self.client_cache.get_active_context()
+
+        if resolved_cluster:
+            log_with_request_id(
+                ctx,
+                LogLevel.DEBUG,
+                f'No cluster provided; using cluster {resolved_cluster} from active context {active_context}.',
+            )
+            return resolved_cluster, active_context
+
+        raise ValueError(
+            'Cluster name is required. Provide cluster_name explicitly or set an active Kubernetes context via set_k8s_context.'
+        )
+
     def get_client(self, cluster_name: str) -> K8sApis:
         """Get a Kubernetes client for the specified cluster.
 
@@ -94,9 +114,10 @@ class K8sHandler:
             description="""Absolute path to the YAML file to apply.
             IMPORTANT: Must be an absolute path (e.g., '/home/user/manifests/app.yaml') as the MCP client and server might not run from the same location.""",
         ),
-        cluster_name: str = Field(
-            ...,
-            description='Name of the EKS cluster where the resources will be created or updated.',
+        cluster_name: Optional[str] = Field(
+            None,
+            description='Name of the EKS cluster where the resources will be created or updated. '
+            'If omitted, the currently active Kubernetes context will be used.',
         ),
         namespace: str = Field(
             ...,
@@ -129,7 +150,7 @@ class K8sHandler:
         Args:
             ctx: MCP context
             yaml_path: Absolute path to the YAML file to apply
-            cluster_name: Name of the EKS cluster
+            cluster_name: Name of the EKS cluster. If omitted, the active context will be resolved.
             namespace: Default namespace to use for resources
             force: Whether to update resources if they already exist (like kubectl apply)
 
@@ -147,6 +168,27 @@ class K8sHandler:
                     force_applied=force,
                     resources_created=0,
                     resources_updated=0,
+                )
+
+            # Resolve cluster name, optionally via active context
+            try:
+                cluster_name, resolved_context = self._resolve_cluster_name(ctx, cluster_name)
+            except ValueError as exc:
+                error_msg = str(exc)
+                log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+                return ApplyYamlResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_msg)],
+                    force_applied=force,
+                    resources_created=0,
+                    resources_updated=0,
+                )
+
+            if resolved_context:
+                log_with_request_id(
+                    ctx,
+                    LogLevel.DEBUG,
+                    f"Resolved cluster '{cluster_name}' from active context '{resolved_context}'.",
                 )
 
             # Get Kubernetes client for the cluster
@@ -303,9 +345,10 @@ class K8sHandler:
             - read: Get details of an existing resource
             Use list_k8s_resources for listing multiple resources.""",
         ),
-        cluster_name: str = Field(
-            ...,
-            description='Name of the EKS cluster where the resource is located or will be created.',
+        cluster_name: Optional[str] = Field(
+            None,
+            description='Name of the EKS cluster where the resource is located or will be created. '
+            'If omitted, the active Kubernetes context will be used.',
         ),
         kind: str = Field(
             ...,
@@ -363,7 +406,7 @@ class K8sHandler:
         Args:
             ctx: MCP context
             operation: Operation to perform (create, replace, patch, delete, read)
-            cluster_name: Name of the EKS cluster
+            cluster_name: Name of the EKS cluster. If omitted, the active context will be resolved.
             kind: Kind of the Kubernetes resource (e.g., 'Pod', 'Service')
             api_version: API version of the Kubernetes resource (e.g., 'v1', 'apps/v1')
             name: Name of the Kubernetes resource
@@ -426,6 +469,29 @@ class K8sHandler:
                     api_version=api_version,
                     operation=operation,
                     resource=None,
+                )
+
+            try:
+                cluster_name, resolved_context = self._resolve_cluster_name(ctx, cluster_name)
+            except ValueError as exc:
+                error_msg = str(exc)
+                log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+                return KubernetesResourceResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_msg)],
+                    kind=kind,
+                    name=name or '',
+                    namespace=namespace,
+                    api_version=api_version,
+                    operation=operation,
+                    resource=None,
+                )
+
+            if resolved_context:
+                log_with_request_id(
+                    ctx,
+                    LogLevel.DEBUG,
+                    f"Resolved cluster '{cluster_name}' from active context '{resolved_context}'.",
                 )
 
             # Get Kubernetes client for the cluster
@@ -505,8 +571,10 @@ class K8sHandler:
     async def list_k8s_resources(
         self,
         ctx: Context,
-        cluster_name: str = Field(
-            ..., description='Name of the EKS cluster where the resources are located.'
+        cluster_name: Optional[str] = Field(
+            None,
+            description='Name of the EKS cluster where the resources are located. '
+            'If omitted, the active Kubernetes context will be used.',
         ),
         kind: str = Field(
             ...,
@@ -556,7 +624,7 @@ class K8sHandler:
 
         Args:
             ctx: MCP context
-            cluster_name: Name of the EKS cluster
+            cluster_name: Name of the EKS cluster. If omitted, the active context will be resolved.
             kind: Kind of the Kubernetes resources (e.g., 'Pod', 'Service')
             api_version: API version of the Kubernetes resources (e.g., 'v1', 'apps/v1')
             namespace: Namespace of the Kubernetes resources (optional)
@@ -567,6 +635,28 @@ class K8sHandler:
             KubernetesResourceListResponse with operation result
         """
         try:
+            try:
+                cluster_name, resolved_context = self._resolve_cluster_name(ctx, cluster_name)
+            except ValueError as exc:
+                error_msg = str(exc)
+                log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+                return KubernetesResourceListResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_msg)],
+                    kind=kind,
+                    api_version=api_version,
+                    namespace=namespace,
+                    count=0,
+                    items=[],
+                )
+
+            if resolved_context:
+                log_with_request_id(
+                    ctx,
+                    LogLevel.DEBUG,
+                    f"Resolved cluster '{cluster_name}' from active context '{resolved_context}'.",
+                )
+
             # Get Kubernetes client for the cluster
             k8s_client = self.get_client(cluster_name)
 
@@ -857,8 +947,10 @@ class K8sHandler:
     async def get_pod_logs(
         self,
         ctx: Context,
-        cluster_name: str = Field(
-            ..., description='Name of the EKS cluster where the pod is running.'
+        cluster_name: Optional[str] = Field(
+            None,
+            description='Name of the EKS cluster where the pod is running. '
+            'If omitted, the active Kubernetes context will be used.',
         ),
         namespace: str = Field(..., description='Kubernetes namespace where the pod is located.'),
         pod_name: str = Field(..., description='Name of the pod to retrieve logs from.'),
@@ -902,7 +994,7 @@ class K8sHandler:
 
         Args:
             ctx: MCP context
-            cluster_name: Name of the EKS cluster
+            cluster_name: Name of the EKS cluster. If omitted, the active context will be resolved.
             namespace: Namespace of the pod
             pod_name: Name of the pod
             container_name: Container name (optional, if pod contains more than one container)
@@ -928,6 +1020,27 @@ class K8sHandler:
             )
 
         try:
+            try:
+                cluster_name, resolved_context = self._resolve_cluster_name(ctx, cluster_name)
+            except ValueError as exc:
+                error_msg = str(exc)
+                log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+                return PodLogsResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_msg)],
+                    pod_name=pod_name,
+                    namespace=namespace,
+                    container_name=container_name,
+                    log_lines=[],
+                )
+
+            if resolved_context:
+                log_with_request_id(
+                    ctx,
+                    LogLevel.DEBUG,
+                    f"Resolved cluster '{cluster_name}' from active context '{resolved_context}'.",
+                )
+
             # Get Kubernetes client for the cluster
             k8s_client = self.get_client(cluster_name)
 
@@ -997,8 +1110,10 @@ class K8sHandler:
     async def get_k8s_events(
         self,
         ctx: Context,
-        cluster_name: str = Field(
-            ..., description='Name of the EKS cluster where the resource is located.'
+        cluster_name: Optional[str] = Field(
+            None,
+            description='Name of the EKS cluster where the resource is located. '
+            'If omitted, the active Kubernetes context will be used.',
         ),
         kind: str = Field(
             ...,
@@ -1036,7 +1151,7 @@ class K8sHandler:
 
         Args:
             ctx: MCP context
-            cluster_name: Name of the EKS cluster
+            cluster_name: Name of the EKS cluster. If omitted, the active context will be resolved.
             kind: Kind of the involved object
             name: Name of the involved object
             namespace: Namespace of the involved object (optional for non-namespaced resources)
@@ -1059,6 +1174,28 @@ class K8sHandler:
             )
 
         try:
+            try:
+                cluster_name, resolved_context = self._resolve_cluster_name(ctx, cluster_name)
+            except ValueError as exc:
+                error_msg = str(exc)
+                log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+                return EventsResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_msg)],
+                    involved_object_kind=kind,
+                    involved_object_name=name,
+                    involved_object_namespace=namespace,
+                    count=0,
+                    events=[],
+                )
+
+            if resolved_context:
+                log_with_request_id(
+                    ctx,
+                    LogLevel.DEBUG,
+                    f"Resolved cluster '{cluster_name}' from active context '{resolved_context}'.",
+                )
+
             # Get Kubernetes client for the cluster
             k8s_client = self.get_client(cluster_name)
 
@@ -1134,8 +1271,10 @@ class K8sHandler:
     async def list_api_versions(
         self,
         ctx: Context,
-        cluster_name: str = Field(
-            ..., description='Name of the EKS cluster to query for available API versions.'
+        cluster_name: Optional[str] = Field(
+            None,
+            description='Name of the EKS cluster to query for available API versions. '
+            'If omitted, the active Kubernetes context will be used.',
         ),
     ) -> ApiVersionsResponse:
         """List all available API versions in the Kubernetes cluster.
@@ -1158,12 +1297,32 @@ class K8sHandler:
 
         Args:
             ctx: MCP context
-            cluster_name: Name of the EKS cluster
+            cluster_name: Name of the EKS cluster. If omitted, the active context will be resolved.
 
         Returns:
             ApiVersionsResponse with list of available API versions
         """
         try:
+            try:
+                cluster_name, resolved_context = self._resolve_cluster_name(ctx, cluster_name)
+            except ValueError as exc:
+                error_msg = str(exc)
+                log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+                return ApiVersionsResponse(
+                    isError=True,
+                    content=[TextContent(type='text', text=error_msg)],
+                    cluster_name=cluster_name or '',
+                    api_versions=[],
+                    count=0,
+                )
+
+            if resolved_context:
+                log_with_request_id(
+                    ctx,
+                    LogLevel.DEBUG,
+                    f"Resolved cluster '{cluster_name}' from active context '{resolved_context}'.",
+                )
+
             # Get Kubernetes client for the cluster
             k8s_client = self.get_client(cluster_name)
 

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/profile_context_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/profile_context_handler.py
@@ -14,14 +14,11 @@
 
 """Profile and context management handler for the EKS MCP Server."""
 
-import os
-from configparser import ConfigParser
-from pathlib import Path
 from typing import Dict, List, Optional
 
-import yaml
+import boto3
 from awslabs.eks_mcp_server.aws_helper import AwsHelper
-from awslabs.eks_mcp_server.k8s_client_cache import K8sClientCache
+from awslabs.eks_mcp_server.k8s_client_cache import K8sClientCache, KubeconfigParseError
 from awslabs.eks_mcp_server.logging_helper import LogLevel, log_with_request_id
 from loguru import logger
 from mcp.server.fastmcp import Context
@@ -54,9 +51,12 @@ class ProfileContextHandler:
     async def set_aws_profile(
         self,
         ctx: Context,
-        profile_name: str = Field(
-            ...,
-            description='Name of the AWS profile to set as active. Must exist in ~/.aws/config or ~/.aws/credentials.',
+        profile_name: Optional[str] = Field(
+            None,
+            description=(
+                'Name of the AWS profile to set as active. Provide no value or "default" to clear the active profile '
+                'and use the standard AWS credential search chain.'
+            ),
         ),
     ) -> str:
         """Set the active AWS profile for subsequent operations.
@@ -72,27 +72,44 @@ class ProfileContextHandler:
         Returns:
             Success message with the active profile name
         """
-        log_with_request_id(ctx, LogLevel.INFO, f'Setting AWS profile to: {profile_name}')
+        log_with_request_id(ctx, LogLevel.DEBUG, f'Request to set AWS profile to: {profile_name}')
         
         try:
+            normalized_profile: Optional[str]
+            if profile_name is None or str(profile_name).strip() == '' or str(profile_name).strip().lower() == 'default':
+                AwsHelper.set_active_profile(None)
+                log_with_request_id(
+                    ctx,
+                    LogLevel.DEBUG,
+                    'Cleared active AWS profile; default credential chain in use.',
+                )
+                return (
+                    'AWS profile cleared. Subsequent operations will use the default AWS credential chain '
+                    '(environment variables, container/instance metadata, etc.).'
+                )
+
+            normalized_profile = str(profile_name).strip()
+
             # Validate that the profile exists
             available_profiles = self._get_aws_profiles()
-            if profile_name not in available_profiles:
+            if normalized_profile not in available_profiles:
                 raise ValueError(
-                    f"Profile '{profile_name}' not found. Available profiles: {', '.join(available_profiles)}"
+                    f"Profile '{normalized_profile}' not found. Available profiles: {', '.join(sorted(available_profiles))}"
                 )
-            
+
             # Set the profile
-            AwsHelper.set_active_profile(profile_name)
-            
+            AwsHelper.set_active_profile(normalized_profile)
+
             log_with_request_id(
                 ctx,
-                LogLevel.INFO,
-                f'Successfully set AWS profile to: {profile_name}',
+                LogLevel.DEBUG,
+                f"Successfully set AWS profile to: {normalized_profile}",
             )
-            
-            return f"AWS profile successfully set to '{profile_name}'. All subsequent AWS operations will use this profile."
-            
+
+            return (
+                f"AWS profile successfully set to '{normalized_profile}'. All subsequent AWS operations will use this profile."
+            )
+
         except Exception as e:
             error_msg = f'Failed to set AWS profile: {str(e)}'
             log_with_request_id(ctx, LogLevel.ERROR, error_msg)
@@ -111,7 +128,7 @@ class ProfileContextHandler:
             Name of the current AWS profile or default credential source
         """
         
-        log_with_request_id(ctx, LogLevel.INFO, 'Getting current AWS profile')
+        log_with_request_id(ctx, LogLevel.DEBUG, 'Getting current AWS profile')
         
         try:
             current_profile = AwsHelper.get_active_profile()
@@ -139,14 +156,14 @@ class ProfileContextHandler:
             Dictionary containing list of available AWS profiles
         """
         
-        log_with_request_id(ctx, LogLevel.INFO, 'Listing available AWS profiles')
+        log_with_request_id(ctx, LogLevel.DEBUG, 'Listing available AWS profiles')
         
         try:
             profiles = self._get_aws_profiles()
             
             log_with_request_id(
                 ctx,
-                LogLevel.INFO,
+                LogLevel.DEBUG,
                 f'Found {len(profiles)} AWS profiles',
             )
             
@@ -182,7 +199,7 @@ class ProfileContextHandler:
             Success message with the active context name
         """
         
-        log_with_request_id(ctx, LogLevel.INFO, f'Setting Kubernetes context to: {context_name}')
+        log_with_request_id(ctx, LogLevel.DEBUG, f'Request to set Kubernetes context to: {context_name}')
         
         try:
             # Validate that the context exists
@@ -198,7 +215,7 @@ class ProfileContextHandler:
             
             log_with_request_id(
                 ctx,
-                LogLevel.INFO,
+                LogLevel.DEBUG,
                 f'Successfully set Kubernetes context to: {context_name}',
             )
             
@@ -222,7 +239,7 @@ class ProfileContextHandler:
             Name of the current Kubernetes context
         """
         
-        log_with_request_id(ctx, LogLevel.INFO, 'Getting current Kubernetes context')
+        log_with_request_id(ctx, LogLevel.DEBUG, 'Getting current Kubernetes context')
         
         try:
             client_cache = K8sClientCache()
@@ -251,14 +268,14 @@ class ProfileContextHandler:
             Dictionary containing list of available Kubernetes contexts
         """
         
-        log_with_request_id(ctx, LogLevel.INFO, 'Listing available Kubernetes contexts')
+        log_with_request_id(ctx, LogLevel.DEBUG, 'Listing available Kubernetes contexts')
         
         try:
             contexts = self._get_k8s_contexts()
             
             log_with_request_id(
                 ctx,
-                LogLevel.INFO,
+                LogLevel.DEBUG,
                 f'Found {len(contexts)} Kubernetes contexts',
             )
             
@@ -278,28 +295,10 @@ class ProfileContextHandler:
         Returns:
             List of profile names
         """
-        profiles = set()
-        
-        # Check ~/.aws/config
-        config_path = Path.home() / '.aws' / 'config'
-        if config_path.exists():
-            config = ConfigParser()
-            config.read(config_path)
-            for section in config.sections():
-                # Profile sections are named 'profile <name>' in config file
-                if section.startswith('profile '):
-                    profiles.add(section.replace('profile ', ''))
-                elif section == 'default':
-                    profiles.add('default')
-        
-        # Check ~/.aws/credentials
-        credentials_path = Path.home() / '.aws' / 'credentials'
-        if credentials_path.exists():
-            config = ConfigParser()
-            config.read(credentials_path)
-            for section in config.sections():
-                profiles.add(section)
-        
+        session = boto3.Session()
+        profiles = set(session.available_profiles)
+        # The default profile is always implicitly available even if not declared
+        profiles.add('default')
         return list(profiles)
 
     def _get_k8s_contexts(self) -> List[str]:
@@ -308,25 +307,11 @@ class ProfileContextHandler:
         Returns:
             List of context names
         """
-        kubeconfig_path = os.environ.get('KUBECONFIG', str(Path.home() / '.kube' / 'config'))
-        
-        if not Path(kubeconfig_path).exists():
-            return []
-        
+        client_cache = K8sClientCache()
         try:
-            with open(kubeconfig_path, 'r') as f:
-                kubeconfig = yaml.safe_load(f)
-            
-            if not kubeconfig or 'contexts' not in kubeconfig:
-                return []
-            
-            contexts = []
-            for context in kubeconfig.get('contexts', []):
-                if 'name' in context:
-                    contexts.append(context['name'])
-            
-            return contexts
-            
-        except Exception as e:
-            logger.error(f'Failed to read kubeconfig: {str(e)}')
+            contexts = client_cache.list_contexts()
+        except KubeconfigParseError as exc:
+            logger.error(f'Failed to parse kubeconfig: {exc}')
             return []
+
+        return contexts

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/profile_context_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/profile_context_handler.py
@@ -1,0 +1,332 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Profile and context management handler for the EKS MCP Server."""
+
+import os
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+from awslabs.eks_mcp_server.aws_helper import AwsHelper
+from awslabs.eks_mcp_server.k8s_client_cache import K8sClientCache
+from awslabs.eks_mcp_server.logging_helper import LogLevel, log_with_request_id
+from loguru import logger
+from mcp.server.fastmcp import Context
+from pydantic import Field
+
+
+class ProfileContextHandler:
+    """Handler for AWS profile and Kubernetes context management.
+    
+    This class provides tools for dynamically switching AWS profiles and
+    Kubernetes contexts without requiring server restart.
+    """
+
+    def __init__(self, mcp):
+        """Initialize the profile and context handler.
+        
+        Args:
+            mcp: The MCP server instance
+        """
+        self.mcp = mcp
+        
+        # Register tools
+        self.mcp.tool(name='set_aws_profile')(self.set_aws_profile)
+        self.mcp.tool(name='get_aws_profile')(self.get_aws_profile)
+        self.mcp.tool(name='list_aws_profiles')(self.list_aws_profiles)
+        self.mcp.tool(name='set_k8s_context')(self.set_k8s_context)
+        self.mcp.tool(name='get_k8s_context')(self.get_k8s_context)
+        self.mcp.tool(name='list_k8s_contexts')(self.list_k8s_contexts)
+
+    async def set_aws_profile(
+        self,
+        ctx: Context,
+        profile_name: str = Field(
+            ...,
+            description='Name of the AWS profile to set as active. Must exist in ~/.aws/config or ~/.aws/credentials.',
+        ),
+    ) -> str:
+        """Set the active AWS profile for subsequent operations.
+        
+        This tool allows you to dynamically switch between AWS profiles without
+        restarting the MCP server. The profile change affects all subsequent
+        AWS API calls until changed again.
+        
+        Args:
+            ctx: MCP context
+            profile_name: Name of the AWS profile to activate
+            
+        Returns:
+            Success message with the active profile name
+        """
+        log_with_request_id(ctx, LogLevel.INFO, f'Setting AWS profile to: {profile_name}')
+        
+        try:
+            # Validate that the profile exists
+            available_profiles = self._get_aws_profiles()
+            if profile_name not in available_profiles:
+                raise ValueError(
+                    f"Profile '{profile_name}' not found. Available profiles: {', '.join(available_profiles)}"
+                )
+            
+            # Set the profile
+            AwsHelper.set_active_profile(profile_name)
+            
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Successfully set AWS profile to: {profile_name}',
+            )
+            
+            return f"AWS profile successfully set to '{profile_name}'. All subsequent AWS operations will use this profile."
+            
+        except Exception as e:
+            error_msg = f'Failed to set AWS profile: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+            raise Exception(error_msg)
+
+    async def get_aws_profile(self, ctx: Context) -> str:
+        """Get the currently active AWS profile.
+        
+        Returns the name of the AWS profile currently being used for AWS API calls.
+        If no profile is explicitly set, returns information about the default profile.
+        
+        Args:
+            ctx: MCP context
+            
+        Returns:
+            Name of the current AWS profile or default credential source
+        """
+        
+        log_with_request_id(ctx, LogLevel.INFO, 'Getting current AWS profile')
+        
+        try:
+            current_profile = AwsHelper.get_active_profile()
+            
+            if current_profile:
+                return f"Current AWS profile: '{current_profile}'"
+            else:
+                return "No AWS profile explicitly set. Using default AWS credential chain (environment variables, instance profile, etc.)."
+                
+        except Exception as e:
+            error_msg = f'Failed to get AWS profile: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+            raise Exception(error_msg)
+
+    async def list_aws_profiles(self, ctx: Context) -> Dict[str, List[str]]:
+        """List all available AWS profiles from configuration files.
+        
+        Reads AWS profiles from ~/.aws/config and ~/.aws/credentials and returns
+        a list of all available profile names that can be used with set_aws_profile.
+        
+        Args:
+            ctx: MCP context
+            
+        Returns:
+            Dictionary containing list of available AWS profiles
+        """
+        
+        log_with_request_id(ctx, LogLevel.INFO, 'Listing available AWS profiles')
+        
+        try:
+            profiles = self._get_aws_profiles()
+            
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Found {len(profiles)} AWS profiles',
+            )
+            
+            return {
+                'profiles': sorted(profiles),
+                'message': f'Found {len(profiles)} AWS profile(s). Use set_aws_profile to switch between them.',
+            }
+            
+        except Exception as e:
+            error_msg = f'Failed to list AWS profiles: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+            raise Exception(error_msg)
+
+    async def set_k8s_context(
+        self,
+        ctx: Context,
+        context_name: str = Field(
+            ...,
+            description='Name of the Kubernetes context to set as active. Must exist in ~/.kube/config.',
+        ),
+    ) -> str:
+        """Set the active Kubernetes context for subsequent operations.
+        
+        This tool allows you to dynamically switch between Kubernetes contexts
+        without restarting the MCP server. The context change affects all subsequent
+        Kubernetes API calls that don't explicitly specify a cluster name.
+        
+        Args:
+            ctx: MCP context
+            context_name: Name of the Kubernetes context to activate
+            
+        Returns:
+            Success message with the active context name
+        """
+        
+        log_with_request_id(ctx, LogLevel.INFO, f'Setting Kubernetes context to: {context_name}')
+        
+        try:
+            # Validate that the context exists
+            available_contexts = self._get_k8s_contexts()
+            if context_name not in available_contexts:
+                raise ValueError(
+                    f"Context '{context_name}' not found. Available contexts: {', '.join(available_contexts)}"
+                )
+            
+            # Set the context in the client cache
+            client_cache = K8sClientCache()
+            client_cache.set_active_context(context_name)
+            
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Successfully set Kubernetes context to: {context_name}',
+            )
+            
+            return f"Kubernetes context successfully set to '{context_name}'. All subsequent Kubernetes operations will use this context."
+            
+        except Exception as e:
+            error_msg = f'Failed to set Kubernetes context: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+            raise Exception(error_msg)
+
+    async def get_k8s_context(self, ctx: Context) -> str:
+        """Get the currently active Kubernetes context.
+        
+        Returns the name of the Kubernetes context currently being used for
+        Kubernetes API calls.
+        
+        Args:
+            ctx: MCP context
+            
+        Returns:
+            Name of the current Kubernetes context
+        """
+        
+        log_with_request_id(ctx, LogLevel.INFO, 'Getting current Kubernetes context')
+        
+        try:
+            client_cache = K8sClientCache()
+            current_context = client_cache.get_active_context()
+            
+            if current_context:
+                return f"Current Kubernetes context: '{current_context}'"
+            else:
+                return "No Kubernetes context explicitly set. Operations require explicit cluster name."
+                
+        except Exception as e:
+            error_msg = f'Failed to get Kubernetes context: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+            raise Exception(error_msg)
+
+    async def list_k8s_contexts(self, ctx: Context) -> Dict[str, List[str]]:
+        """List all available Kubernetes contexts from kubeconfig.
+        
+        Reads Kubernetes contexts from ~/.kube/config and returns a list of all
+        available context names that can be used with set_k8s_context.
+        
+        Args:
+            ctx: MCP context
+            
+        Returns:
+            Dictionary containing list of available Kubernetes contexts
+        """
+        
+        log_with_request_id(ctx, LogLevel.INFO, 'Listing available Kubernetes contexts')
+        
+        try:
+            contexts = self._get_k8s_contexts()
+            
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f'Found {len(contexts)} Kubernetes contexts',
+            )
+            
+            return {
+                'contexts': sorted(contexts),
+                'message': f'Found {len(contexts)} Kubernetes context(s). Use set_k8s_context to switch between them.',
+            }
+            
+        except Exception as e:
+            error_msg = f'Failed to list Kubernetes contexts: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+            raise Exception(error_msg)
+
+    def _get_aws_profiles(self) -> List[str]:
+        """Get list of available AWS profiles from config files.
+        
+        Returns:
+            List of profile names
+        """
+        profiles = set()
+        
+        # Check ~/.aws/config
+        config_path = Path.home() / '.aws' / 'config'
+        if config_path.exists():
+            config = ConfigParser()
+            config.read(config_path)
+            for section in config.sections():
+                # Profile sections are named 'profile <name>' in config file
+                if section.startswith('profile '):
+                    profiles.add(section.replace('profile ', ''))
+                elif section == 'default':
+                    profiles.add('default')
+        
+        # Check ~/.aws/credentials
+        credentials_path = Path.home() / '.aws' / 'credentials'
+        if credentials_path.exists():
+            config = ConfigParser()
+            config.read(credentials_path)
+            for section in config.sections():
+                profiles.add(section)
+        
+        return list(profiles)
+
+    def _get_k8s_contexts(self) -> List[str]:
+        """Get list of available Kubernetes contexts from kubeconfig.
+        
+        Returns:
+            List of context names
+        """
+        kubeconfig_path = os.environ.get('KUBECONFIG', str(Path.home() / '.kube' / 'config'))
+        
+        if not Path(kubeconfig_path).exists():
+            return []
+        
+        try:
+            with open(kubeconfig_path, 'r') as f:
+                kubeconfig = yaml.safe_load(f)
+            
+            if not kubeconfig or 'contexts' not in kubeconfig:
+                return []
+            
+            contexts = []
+            for context in kubeconfig.get('contexts', []):
+                if 'name' in context:
+                    contexts.append(context['name'])
+            
+            return contexts
+            
+        except Exception as e:
+            logger.error(f'Failed to read kubeconfig: {str(e)}')
+            return []

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/server.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/server.py
@@ -31,6 +31,7 @@ from awslabs.eks_mcp_server.eks_stack_handler import EksStackHandler
 from awslabs.eks_mcp_server.iam_handler import IAMHandler
 from awslabs.eks_mcp_server.insights_handler import InsightsHandler
 from awslabs.eks_mcp_server.k8s_handler import K8sHandler
+from awslabs.eks_mcp_server.profile_context_handler import ProfileContextHandler
 from awslabs.eks_mcp_server.vpc_config_handler import VpcConfigHandler
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
@@ -46,6 +47,30 @@ This MCP server provides tools for managing Amazon EKS clusters and is the prefe
 
 DO NOT use standard EKS and Kubernetes CLI commands (aws eks, eksctl, kubectl). Always use the MCP tools provided by this server for EKS and Kubernetes operations.
 
+## Multi-Profile and Multi-Context Support
+
+This server supports dynamic AWS profile and Kubernetes context switching, enabling management of multiple EKS clusters across different AWS accounts without server restart.
+
+### AWS Profile Management
+
+- **list_aws_profiles**: List all available AWS profiles from ~/.aws/config and ~/.aws/credentials
+- **set_aws_profile**: Switch to a different AWS profile dynamically
+- **get_aws_profile**: Get the currently active AWS profile
+
+### Kubernetes Context Management
+
+- **list_k8s_contexts**: List all available Kubernetes contexts from ~/.kube/config
+- **set_k8s_context**: Switch to a different Kubernetes context dynamically
+- **get_k8s_context**: Get the currently active Kubernetes context
+
+### Multi-Cluster Workflow Example
+
+1. List available AWS profiles: `list_aws_profiles()`
+2. Switch to desired profile: `set_aws_profile(profile_name='production')`
+3. List available contexts: `list_k8s_contexts()`
+4. Switch to desired context: `set_k8s_context(context_name='prod-cluster')`
+5. Perform operations on the selected cluster/context
+
 ## Usage Notes
 
 - By default, the server runs in read-only mode. Use the `--allow-write` flag to enable write operations.
@@ -53,6 +78,7 @@ DO NOT use standard EKS and Kubernetes CLI commands (aws eks, eksctl, kubectl). 
 - For safety reasons, CloudFormation stacks can only be modified by the tool that created them.
 - When creating or updating resources, always check for existing resources first to avoid conflicts.
 - Use the `list_api_versions` tool to find the correct apiVersion for Kubernetes resources.
+- Profile and context changes affect all subsequent operations until changed again.
 
 ## Common Workflows
 
@@ -80,6 +106,8 @@ DO NOT use standard EKS and Kubernetes CLI commands (aws eks, eksctl, kubectl). 
 - Follow the principle of least privilege when creating IAM policies.
 - Use the search_eks_troubleshoot_guide tool when encountering common EKS issues.
 - Always verify API versions with list_api_versions before creating resources.
+- When managing multiple clusters, use profile and context switching tools to organize your work.
+- List available profiles and contexts before switching to ensure they exist.
 """
 
 SERVER_DEPENDENCIES = [
@@ -145,6 +173,7 @@ def main():
     mcp = create_server()
 
     # Initialize handlers - all tools are always registered, access control is handled within tools
+    ProfileContextHandler(mcp)
     CloudWatchHandler(mcp, allow_sensitive_data_access)
     EKSKnowledgeBaseHandler(mcp)
     EksStackHandler(mcp, allow_write)

--- a/src/eks-mcp-server/tests/test_aws_helper.py
+++ b/src/eks-mcp-server/tests/test_aws_helper.py
@@ -15,6 +15,7 @@
 """Tests for the AWS Helper."""
 
 import os
+import threading
 from awslabs.eks_mcp_server import __version__
 from awslabs.eks_mcp_server.aws_helper import AwsHelper
 from unittest.mock import ANY, MagicMock, patch
@@ -27,6 +28,7 @@ class TestAwsHelper:
         """Set up the test environment."""
         # Clear the client cache before each test
         AwsHelper._client_cache = {}
+        AwsHelper._active_profile = None
 
     @patch.dict(os.environ, {'AWS_REGION': 'us-west-2'})
     def test_get_aws_region_from_env(self):
@@ -52,35 +54,39 @@ class TestAwsHelper:
         profile = AwsHelper.get_aws_profile()
         assert profile is None
 
-    @patch('boto3.client')
-    def test_create_boto3_client_no_profile_with_region(self, mock_boto3_client):
-        """Test that create_boto3_client creates a client with the correct parameters when no profile is set but region is in env."""
-        # Mock the get_aws_profile method to return None
-        with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
-            # Mock the get_aws_region method to return a specific region
-            with patch.dict(os.environ, {'AWS_REGION': 'us-west-2'}):
+    @patch('boto3.Session')
+    def test_create_boto3_client_no_profile_with_region(self, mock_session_cls):
+        """Test client creation with environment region and no explicit profile."""
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        with patch.dict(os.environ, {'AWS_REGION': 'us-west-2'}):
+            with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
                 with patch.object(AwsHelper, 'get_aws_region', return_value='us-west-2'):
-                    # Call the create_boto3_client method
                     AwsHelper.create_boto3_client('cloudformation')
 
-                    # Verify that boto3.client was called with the correct parameters
-                    mock_boto3_client.assert_called_once_with(
-                        'cloudformation', region_name='us-west-2', config=ANY
-                    )
+        mock_session_cls.assert_called_once_with(region_name='us-west-2')
+        mock_session.client.assert_called_once_with(
+            'cloudformation', region_name='us-west-2', config=ANY
+        )
 
-    @patch('boto3.client')
-    def test_create_boto3_client_no_profile_no_region(self, mock_boto3_client):
-        """Test that create_boto3_client creates a client without region when no profile or region is set."""
-        # Mock the get_aws_profile method to return None
-        with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
-            # Mock the get_aws_region method to return None
-            with patch.dict(os.environ, {}, clear=True):
+    @patch('boto3.Session')
+    def test_create_boto3_client_no_profile_no_region(self, mock_session_cls):
+        """Test client creation without region or profile uses default session."""
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
                 with patch.object(AwsHelper, 'get_aws_region', return_value=None):
-                    # Call the create_boto3_client method
                     AwsHelper.create_boto3_client('cloudformation')
 
-                    # Verify that boto3.client was called without region_name
-                    mock_boto3_client.assert_called_once_with('cloudformation', config=ANY)
+        mock_session_cls.assert_called_once_with()
+        mock_session.client.assert_called_once_with('cloudformation', config=ANY)
 
     @patch('boto3.Session')
     def test_create_boto3_client_with_profile_with_region(self, mock_boto3_session):
@@ -98,7 +104,9 @@ class TestAwsHelper:
                     AwsHelper.create_boto3_client('cloudformation')
 
                     # Verify that boto3.Session was called with the correct parameters
-                    mock_boto3_session.assert_called_once_with(profile_name='test-profile')
+                    mock_boto3_session.assert_called_once_with(
+                        profile_name='test-profile', region_name='us-west-2'
+                    )
 
                     # Verify that session.client was called with the correct parameters
                     mock_session.client.assert_called_once_with(
@@ -126,88 +134,86 @@ class TestAwsHelper:
                     # Verify that session.client was called without region_name
                     mock_session.client.assert_called_once_with('cloudformation', config=ANY)
 
-    @patch('boto3.client')
-    def test_create_boto3_client_with_region_override(self, mock_boto3_client):
-        """Test that create_boto3_client uses the region override when provided."""
-        # Mock the get_aws_profile method to return None
+    @patch('boto3.Session')
+    def test_create_boto3_client_with_region_override(self, mock_session_cls):
+        """Test that explicit region argument overrides environment/default."""
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
         with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
-            # Call the create_boto3_client method with a region override
             AwsHelper.create_boto3_client('cloudformation', region_name='eu-west-1')
 
-            # Verify that boto3.client was called with the correct parameters
-            mock_boto3_client.assert_called_once_with(
-                'cloudformation', region_name='eu-west-1', config=ANY
-            )
+        mock_session_cls.assert_called_once_with(region_name='eu-west-1')
+        mock_session.client.assert_called_once_with(
+            'cloudformation', region_name='eu-west-1', config=ANY
+        )
 
     def test_create_boto3_client_user_agent(self):
         """Test that create_boto3_client sets the user agent suffix correctly using the package version."""
         # Create a real Config object to inspect
         with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
             with patch.object(AwsHelper, 'get_aws_region', return_value=None):
-                with patch('boto3.client') as mock_client:
-                    # Call the create_boto3_client method
+                with patch('boto3.Session') as mock_session_cls:
+                    mock_session = MagicMock()
+                    mock_client = MagicMock()
+                    mock_session.client.return_value = mock_client
+                    mock_session_cls.return_value = mock_session
+
                     AwsHelper.create_boto3_client('cloudformation')
 
-                    # Get the config argument passed to boto3.client
-                    _, kwargs = mock_client.call_args
+                    _, kwargs = mock_session.client.call_args
                     config = kwargs.get('config')
 
-                    # Verify the user agent suffix uses the version from __init__.py
                     assert config is not None
                     expected_user_agent = f'awslabs/mcp/eks-mcp-server/{__version__}'
                     assert config.user_agent_extra == expected_user_agent
 
-    @patch('boto3.client')
-    def test_client_caching(self, mock_boto3_client):
-        """Test that clients are cached and reused."""
-        # Create a mock client
+    @patch('boto3.Session')
+    def test_client_caching(self, mock_session_cls):
+        """Test that identical service/region/profile combinations reuse cached clients."""
+        mock_session = MagicMock()
         mock_client = MagicMock()
-        mock_boto3_client.return_value = mock_client
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
 
-        # Mock the get_aws_profile and get_aws_region methods
         with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
             with patch.object(AwsHelper, 'get_aws_region', return_value='us-west-2'):
-                # Call create_boto3_client twice with the same parameters
                 client1 = AwsHelper.create_boto3_client('cloudformation')
                 client2 = AwsHelper.create_boto3_client('cloudformation')
 
-                # Verify that boto3.client was called only once
-                mock_boto3_client.assert_called_once()
+        mock_session_cls.assert_called_once_with(region_name='us-west-2')
+        mock_session.client.assert_called_once()
+        assert client1 is client2
 
-                # Verify that the same client instance was returned both times
-                assert client1 is client2
-
-    @patch('boto3.client')
-    def test_different_services_not_cached_together(self, mock_boto3_client):
-        """Test that different services get different cached clients."""
-        # Create mock clients
+    @patch('boto3.Session')
+    def test_different_services_not_cached_together(self, mock_session_cls):
+        """Test that each service gets its own cached client entry."""
+        mock_session = MagicMock()
         mock_cf_client = MagicMock()
         mock_s3_client = MagicMock()
-        mock_boto3_client.side_effect = [mock_cf_client, mock_s3_client]
+        mock_session.client.side_effect = [mock_cf_client, mock_s3_client]
+        mock_session_cls.return_value = mock_session
 
-        # Mock the get_aws_profile and get_aws_region methods
         with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
             with patch.object(AwsHelper, 'get_aws_region', return_value='us-west-2'):
-                # Call create_boto3_client for different services
                 cf_client = AwsHelper.create_boto3_client('cloudformation')
                 s3_client = AwsHelper.create_boto3_client('s3')
 
-                # Verify that boto3.client was called twice
-                assert mock_boto3_client.call_count == 2
+        assert mock_session.client.call_count == 2
+        assert cf_client is not s3_client
 
-                # Verify that different client instances were returned
-                assert cf_client is not s3_client
+    @patch('boto3.Session')
+    def test_same_service_different_regions_not_cached_together(self, mock_session_cls):
+        """Test that changing region results in a new cached client."""
+        mock_session = MagicMock()
+        mock_us_client = MagicMock()
+        mock_eu_client = MagicMock()
+        mock_session.client.side_effect = [mock_us_client, mock_eu_client]
+        mock_session_cls.return_value = mock_session
 
-    @patch('boto3.client')
-    def test_same_service_different_regions_cached_together(self, mock_boto3_client):
-        """Test that clients for the same service are cached together regardless of region."""
-        # Create mock client
-        mock_client = MagicMock()
-        mock_boto3_client.return_value = mock_client
-
-        # Mock the get_aws_profile method
         with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
-            # Call create_boto3_client for different regions
             us_west_client = AwsHelper.create_boto3_client(
                 'cloudformation', region_name='us-west-2'
             )
@@ -215,17 +221,16 @@ class TestAwsHelper:
                 'cloudformation', region_name='eu-west-1'
             )
 
-            # Verify that boto3.client was called only once
-            mock_boto3_client.assert_called_once()
+        assert mock_session.client.call_count == 2
+        assert us_west_client is not eu_west_client
 
-            # Verify that the same client instance was returned both times
-            assert us_west_client is eu_west_client
-
-    @patch('boto3.client')
-    def test_error_handling(self, mock_boto3_client):
+    @patch('boto3.Session')
+    def test_error_handling(self, mock_session_cls):
         """Test that errors during client creation are handled properly."""
         # Make boto3.client raise an exception
-        mock_boto3_client.side_effect = Exception('Test error')
+        mock_session = MagicMock()
+        mock_session.client.side_effect = Exception('Test error')
+        mock_session_cls.return_value = mock_session
 
         # Mock the get_aws_profile and get_aws_region methods
         with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
@@ -238,34 +243,33 @@ class TestAwsHelper:
                     assert 'Failed to create boto3 client for cloudformation: Test error' in str(e)
 
     @patch('boto3.Session')
-    def test_same_service_different_profiles_cached_together(self, mock_boto3_session):
-        """Test that clients for the same service are cached together regardless of profile."""
-        # Create mock session and client
-        mock_session = MagicMock()
-        mock_client = MagicMock()
-        mock_session.client.return_value = mock_client
-        mock_boto3_session.return_value = mock_session
+    def test_same_service_different_profiles_not_cached_together(self, mock_boto3_session):
+        """Test that changing profile invalidates cached client."""
+        mock_session1 = MagicMock()
+        mock_client1 = MagicMock()
+        mock_session1.client.return_value = mock_client1
 
-        # Call create_boto3_client with different profiles
-        with patch.object(AwsHelper, 'get_aws_profile', return_value='profile1'):
-            with patch.object(AwsHelper, 'get_aws_region', return_value=None):
+        mock_session2 = MagicMock()
+        mock_client2 = MagicMock()
+        mock_session2.client.return_value = mock_client2
+
+        mock_boto3_session.side_effect = [mock_session1, mock_session2]
+
+        with patch.object(AwsHelper, 'get_aws_region', return_value=None):
+            with patch.object(AwsHelper, 'get_aws_profile', return_value='profile1'):
                 client1 = AwsHelper.create_boto3_client('cloudformation')
 
-        with patch.object(AwsHelper, 'get_aws_profile', return_value='profile2'):
-            with patch.object(AwsHelper, 'get_aws_region', return_value=None):
+            with patch.object(AwsHelper, 'get_aws_profile', return_value='profile2'):
                 client2 = AwsHelper.create_boto3_client('cloudformation')
 
-        # Verify that boto3.Session was called only once
-        mock_boto3_session.assert_called_once()
-
-        # Verify that the same client instance was returned both times
-        assert client1 is client2
+        assert mock_boto3_session.call_count == 2
+        assert client1 is not client2
 
     def test_set_active_profile(self):
         """Test that set_active_profile sets the profile and clears cache."""
         # Add some items to the cache
-        AwsHelper._client_cache['s3'] = MagicMock()
-        AwsHelper._client_cache['ec2'] = MagicMock()
+        AwsHelper._client_cache[('s3', None, None)] = MagicMock()
+        AwsHelper._client_cache[('ec2', None, None)] = MagicMock()
         
         # Set active profile
         AwsHelper.set_active_profile('test-profile')
@@ -387,7 +391,35 @@ class TestAwsHelper:
             AwsHelper.create_boto3_client('s3')
         
         # Verify Session was created with SSO profile
-        mock_boto3_session.assert_called_once_with(profile_name='my-sso-profile')
+        mock_boto3_session.assert_called_once_with(
+            profile_name='my-sso-profile', region_name='us-east-1'
+        )
         
         # Verify client was created with region
         mock_session.client.assert_called_once_with('s3', region_name='us-east-1', config=ANY)
+
+    @patch('boto3.Session')
+    def test_create_boto3_client_thread_safe(self, mock_boto3_session):
+        """Test that concurrent client creation uses cached instance."""
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3_session.return_value = mock_session
+
+        def worker(results):
+            client = AwsHelper.create_boto3_client('s3', region_name='us-east-1')
+            results.append(client)
+
+        threads = []
+        results = []
+        for _ in range(5):
+            thread = threading.Thread(target=worker, args=(results,))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Ensure only one underlying client creation occurred
+        mock_session.client.assert_called_once()
+        assert len({id(client) for client in results}) == 1

--- a/src/eks-mcp-server/tests/test_aws_helper.py
+++ b/src/eks-mcp-server/tests/test_aws_helper.py
@@ -260,3 +260,134 @@ class TestAwsHelper:
 
         # Verify that the same client instance was returned both times
         assert client1 is client2
+
+    def test_set_active_profile(self):
+        """Test that set_active_profile sets the profile and clears cache."""
+        # Add some items to the cache
+        AwsHelper._client_cache['s3'] = MagicMock()
+        AwsHelper._client_cache['ec2'] = MagicMock()
+        
+        # Set active profile
+        AwsHelper.set_active_profile('test-profile')
+        
+        # Verify profile was set
+        assert AwsHelper._active_profile == 'test-profile'
+        
+        # Verify cache was cleared
+        assert len(AwsHelper._client_cache) == 0
+
+    def test_set_active_profile_to_none(self):
+        """Test that set_active_profile can be set to None."""
+        # Set active profile to a value first
+        AwsHelper._active_profile = 'test-profile'
+        
+        # Set to None
+        AwsHelper.set_active_profile(None)
+        
+        # Verify profile was set to None
+        assert AwsHelper._active_profile is None
+
+    def test_get_active_profile_when_set(self):
+        """Test that get_active_profile returns the active profile when set."""
+        # Set active profile
+        AwsHelper._active_profile = 'test-profile'
+        
+        # Get active profile
+        profile = AwsHelper.get_active_profile()
+        
+        # Verify correct profile was returned
+        assert profile == 'test-profile'
+
+    @patch.dict(os.environ, {'AWS_PROFILE': 'env-profile'})
+    def test_get_active_profile_falls_back_to_env(self):
+        """Test that get_active_profile falls back to environment variable when not set."""
+        # Ensure active profile is None
+        AwsHelper._active_profile = None
+        
+        # Get active profile
+        profile = AwsHelper.get_active_profile()
+        
+        # Verify env profile was returned
+        assert profile == 'env-profile'
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_active_profile_returns_none_when_not_set(self):
+        """Test that get_active_profile returns None when neither active profile nor env is set."""
+        # Ensure active profile is None
+        AwsHelper._active_profile = None
+        
+        # Get active profile
+        profile = AwsHelper.get_active_profile()
+        
+        # Verify None was returned
+        assert profile is None
+
+    @patch('boto3.Session')
+    def test_active_profile_overrides_env_profile(self, mock_boto3_session):
+        """Test that active profile overrides environment variable."""
+        # Create mock session
+        mock_session = MagicMock()
+        mock_boto3_session.return_value = mock_session
+        
+        # Set environment profile
+        with patch.dict(os.environ, {'AWS_PROFILE': 'env-profile'}):
+            # Set active profile to override
+            AwsHelper.set_active_profile('active-profile')
+            
+            # Create client
+            AwsHelper.create_boto3_client('s3')
+            
+            # Verify Session was created with active profile, not env profile
+            mock_boto3_session.assert_called_once_with(profile_name='active-profile')
+
+    @patch('boto3.Session')
+    def test_profile_switching_clears_cache(self, mock_boto3_session):
+        """Test that switching profiles causes clients to be recreated."""
+        # Create mock sessions and clients
+        mock_session1 = MagicMock()
+        mock_client1 = MagicMock()
+        mock_session1.client.return_value = mock_client1
+        
+        mock_session2 = MagicMock()
+        mock_client2 = MagicMock()
+        mock_session2.client.return_value = mock_client2
+        
+        mock_boto3_session.side_effect = [mock_session1, mock_session2]
+        
+        # Create client with first profile
+        AwsHelper.set_active_profile('profile1')
+        with patch.object(AwsHelper, 'get_aws_region', return_value=None):
+            client1 = AwsHelper.create_boto3_client('s3')
+        
+        # Switch profile
+        AwsHelper.set_active_profile('profile2')
+        
+        # Create client again
+        with patch.object(AwsHelper, 'get_aws_region', return_value=None):
+            client2 = AwsHelper.create_boto3_client('s3')
+        
+        # Verify both sessions were created
+        assert mock_boto3_session.call_count == 2
+        
+        # Verify different clients were returned
+        assert client1 is not client2
+
+    @patch('boto3.Session')
+    def test_aws_sso_profile_support(self, mock_boto3_session):
+        """Test that AWS SSO profiles work correctly."""
+        # Create mock session
+        mock_session = MagicMock()
+        mock_boto3_session.return_value = mock_session
+        
+        # Set an SSO profile
+        AwsHelper.set_active_profile('my-sso-profile')
+        
+        # Create client
+        with patch.object(AwsHelper, 'get_aws_region', return_value='us-east-1'):
+            AwsHelper.create_boto3_client('s3')
+        
+        # Verify Session was created with SSO profile
+        mock_boto3_session.assert_called_once_with(profile_name='my-sso-profile')
+        
+        # Verify client was created with region
+        mock_session.client.assert_called_once_with('s3', region_name='us-east-1', config=ANY)

--- a/src/eks-mcp-server/tests/test_k8s_client_cache.py
+++ b/src/eks-mcp-server/tests/test_k8s_client_cache.py
@@ -414,3 +414,227 @@ class TestK8sClientCache:
 
             # Verify that describe_cluster was called with the correct parameters
             mock_eks_client.describe_cluster.assert_called_once_with(name='test-cluster')
+
+    def test_set_active_context(self):
+        """Test set_active_context method."""
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Add some items to the cache
+        cache._client_cache['cluster1'] = MagicMock()
+        cache._client_cache['cluster2'] = MagicMock()
+        
+        # Set active context
+        cache.set_active_context('test-context')
+        
+        # Verify context was set
+        assert cache._active_context == 'test-context'
+        
+        # Verify cache was cleared
+        assert len(cache._client_cache) == 0
+
+    def test_get_active_context_when_set(self):
+        """Test get_active_context when context is set."""
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Set context
+        cache._active_context = 'test-context'
+        
+        # Get context
+        context = cache.get_active_context()
+        
+        # Verify correct context was returned
+        assert context == 'test-context'
+
+    def test_get_active_context_when_not_set(self):
+        """Test get_active_context when context is not set."""
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Ensure context is None
+        cache._active_context = None
+        
+        # Get context
+        context = cache.get_active_context()
+        
+        # Verify None was returned
+        assert context is None
+
+    def test_context_switching_clears_cache(self):
+        """Test that switching contexts clears the client cache."""
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Add clients to cache
+        cache._client_cache['cluster1'] = MagicMock()
+        cache._client_cache['cluster2'] = MagicMock()
+        initial_cache_size = len(cache._client_cache)
+        
+        assert initial_cache_size == 2
+        
+        # Switch context
+        cache.set_active_context('new-context')
+        
+        # Verify cache was cleared
+        assert len(cache._client_cache) == 0
+
+    def test_get_cluster_from_context_valid(self):
+        """Test get_cluster_from_context with valid context."""
+        import tempfile
+        import yaml
+        from pathlib import Path
+        
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Create temporary kubeconfig
+        with tempfile.TemporaryDirectory() as temp_dir:
+            kubeconfig_path = Path(temp_dir) / 'config'
+            kubeconfig = {
+                'apiVersion': 'v1',
+                'kind': 'Config',
+                'contexts': [
+                    {
+                        'name': 'test-context',
+                        'context': {
+                            'cluster': 'test-cluster',
+                            'user': 'test-user'
+                        }
+                    }
+                ],
+                'clusters': [
+                    {
+                        'name': 'test-cluster',
+                        'cluster': {
+                            'server': 'https://test-server'
+                        }
+                    }
+                ],
+                'users': [
+                    {
+                        'name': 'test-user',
+                        'user': {}
+                    }
+                ]
+            }
+            
+            with open(kubeconfig_path, 'w') as f:
+                yaml.dump(kubeconfig, f)
+            
+            # Set KUBECONFIG env var
+            with patch.dict('os.environ', {'KUBECONFIG': str(kubeconfig_path)}):
+                # Get cluster from context
+                cluster = cache.get_cluster_from_context('test-context')
+                
+                # Verify correct cluster was returned
+                assert cluster == 'test-cluster'
+
+    def test_get_cluster_from_context_invalid(self):
+        """Test get_cluster_from_context with invalid context."""
+        import tempfile
+        import yaml
+        from pathlib import Path
+        
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Create temporary kubeconfig
+        with tempfile.TemporaryDirectory() as temp_dir:
+            kubeconfig_path = Path(temp_dir) / 'config'
+            kubeconfig = {
+                'apiVersion': 'v1',
+                'kind': 'Config',
+                'contexts': [
+                    {
+                        'name': 'test-context',
+                        'context': {
+                            'cluster': 'test-cluster',
+                            'user': 'test-user'
+                        }
+                    }
+                ]
+            }
+            
+            with open(kubeconfig_path, 'w') as f:
+                yaml.dump(kubeconfig, f)
+            
+            # Set KUBECONFIG env var
+            with patch.dict('os.environ', {'KUBECONFIG': str(kubeconfig_path)}):
+                # Get cluster from non-existent context
+                cluster = cache.get_cluster_from_context('nonexistent-context')
+                
+                # Verify None was returned
+                assert cluster is None
+
+    def test_get_cluster_from_context_no_kubeconfig(self):
+        """Test get_cluster_from_context when kubeconfig doesn't exist."""
+        import tempfile
+        from pathlib import Path
+        
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Set KUBECONFIG to non-existent file
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_path = Path(temp_dir) / 'nonexistent' / 'config'
+            with patch.dict('os.environ', {'KUBECONFIG': str(fake_path)}):
+                # Get cluster from context
+                cluster = cache.get_cluster_from_context('test-context')
+                
+                # Verify None was returned
+                assert cluster is None
+
+    def test_get_cluster_from_context_uses_active_context(self):
+        """Test get_cluster_from_context uses active context when none specified."""
+        import tempfile
+        import yaml
+        from pathlib import Path
+        
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Set active context
+        cache._active_context = 'active-context'
+        
+        # Create temporary kubeconfig
+        with tempfile.TemporaryDirectory() as temp_dir:
+            kubeconfig_path = Path(temp_dir) / 'config'
+            kubeconfig = {
+                'apiVersion': 'v1',
+                'kind': 'Config',
+                'contexts': [
+                    {
+                        'name': 'active-context',
+                        'context': {
+                            'cluster': 'active-cluster',
+                            'user': 'test-user'
+                        }
+                    }
+                ]
+            }
+            
+            with open(kubeconfig_path, 'w') as f:
+                yaml.dump(kubeconfig, f)
+            
+            # Set KUBECONFIG env var
+            with patch.dict('os.environ', {'KUBECONFIG': str(kubeconfig_path)}):
+                # Get cluster from context (no context specified)
+                cluster = cache.get_cluster_from_context()
+                
+                # Verify correct cluster was returned
+                assert cluster == 'active-cluster'
+
+    def test_get_cluster_from_context_no_active_context(self):
+        """Test get_cluster_from_context when no active context and none specified."""
+        # Create a K8sClientCache instance
+        cache = K8sClientCache()
+        
+        # Ensure no active context
+        cache._active_context = None
+        
+        # Get cluster from context (no context specified)
+        cluster = cache.get_cluster_from_context()
+        
+        # Verify None was returned
+        assert cluster is None

--- a/src/eks-mcp-server/tests/test_profile_context_handler.py
+++ b/src/eks-mcp-server/tests/test_profile_context_handler.py
@@ -1,0 +1,363 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ruff: noqa: D101, D102, D103
+"""Tests for the Profile Context Handler."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from awslabs.eks_mcp_server.aws_helper import AwsHelper
+from awslabs.eks_mcp_server.k8s_client_cache import K8sClientCache
+from awslabs.eks_mcp_server.profile_context_handler import ProfileContextHandler
+from mcp.server.fastmcp import Context
+
+
+class TestProfileContextHandler:
+    """Tests for the ProfileContextHandler class."""
+
+    def setup_method(self):
+        """Set up the test environment."""
+        # Clear caches and state
+        AwsHelper._client_cache = {}
+        AwsHelper._active_profile = None
+        
+        # Reset K8sClientCache singleton
+        K8sClientCache._instance = None
+
+    @pytest.fixture
+    def mock_mcp(self):
+        """Create a mock MCP server."""
+        mcp = MagicMock()
+        mcp.tool = lambda name: lambda func: func
+        return mcp
+
+    @pytest.fixture
+    def handler(self, mock_mcp):
+        """Create a ProfileContextHandler instance."""
+        return ProfileContextHandler(mock_mcp)
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock context."""
+        context = MagicMock(spec=Context)
+        context.request_id = 'test-request-id'
+        return context
+
+    @pytest.fixture
+    def temp_aws_config(self):
+        """Create a temporary AWS config file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            aws_dir = Path(temp_dir) / '.aws'
+            aws_dir.mkdir()
+            
+            # Create config file
+            config_file = aws_dir / 'config'
+            config_file.write_text("""[default]
+region = us-east-1
+
+[profile test-profile]
+region = us-west-2
+
+[profile sso-profile]
+sso_start_url = https://my-sso-portal.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = AdminRole
+region = us-west-2
+
+[profile another-profile]
+region = eu-west-1
+""")
+            
+            # Create credentials file
+            creds_file = aws_dir / 'credentials'
+            creds_file.write_text("""[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXHELLO/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[test-profile]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE2
+aws_secret_access_key = wJalrXGOODBYE/K7MDENG/bPxRfiCYEXAMPLEKEY2
+
+[creds-only-profile]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE3
+aws_secret_access_key = wJalrXHIHIHI/K7MDENG/bPxRfiCYEXAMPLEKEY3
+""")
+            
+            yield aws_dir
+
+    @pytest.fixture
+    def temp_kubeconfig(self):
+        """Create a temporary kubeconfig file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            kube_dir = Path(temp_dir) / '.kube'
+            kube_dir.mkdir()
+            
+            config_file = kube_dir / 'config'
+            config_file.write_text("""apiVersion: v1
+kind: Config
+current-context: context1
+contexts:
+- name: context1
+  context:
+    cluster: cluster1
+    user: user1
+- name: context2
+  context:
+    cluster: cluster2
+    user: user2
+- name: eks-cluster-context
+  context:
+    cluster: eks-cluster
+    user: eks-user
+clusters:
+- name: cluster1
+  cluster:
+    server: https://kubernetes.example.com:6443
+- name: cluster2
+  cluster:
+    server: https://kubernetes2.example.com:6443
+- name: eks-cluster
+  cluster:
+    server: https://eks.us-west-2.amazonaws.com
+users:
+- name: user1
+  user:
+    token: token1
+- name: user2
+  user:
+    token: token2
+- name: eks-user
+  user:
+    exec:
+      command: aws
+      args:
+      - eks
+      - get-token
+      - --cluster-name
+      - eks-cluster
+""")
+            
+            yield config_file
+
+    @pytest.mark.asyncio
+    async def test_list_aws_profiles(self, handler, mock_context, temp_aws_config):
+        """Test listing AWS profiles from config files."""
+        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+            result = await handler.list_aws_profiles(mock_context)
+            
+            # Verify profiles were found
+            assert 'profiles' in result
+            assert 'default' in result['profiles']
+            assert 'test-profile' in result['profiles']
+            assert 'sso-profile' in result['profiles']
+            assert 'another-profile' in result['profiles']
+            assert 'creds-only-profile' in result['profiles']
+
+    @pytest.mark.asyncio
+    async def test_list_aws_profiles_no_config_files(self, handler, mock_context):
+        """Test listing AWS profiles when config files don't exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(Path, 'home', return_value=Path(temp_dir)):
+                result = await handler.list_aws_profiles(mock_context)
+                
+                # Should return empty list
+                assert 'profiles' in result
+                assert len(result['profiles']) == 0
+
+    @pytest.mark.asyncio
+    async def test_set_aws_profile_valid(self, handler, mock_context, temp_aws_config):
+        """Test setting a valid AWS profile."""
+        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+            result = await handler.set_aws_profile(mock_context, 'test-profile')
+            
+            # Verify profile was set
+            assert 'test-profile' in result
+            assert AwsHelper.get_active_profile() == 'test-profile'
+
+    @pytest.mark.asyncio
+    async def test_set_aws_profile_sso(self, handler, mock_context, temp_aws_config):
+        """Test setting an AWS SSO profile."""
+        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+            result = await handler.set_aws_profile(mock_context, 'sso-profile')
+            
+            # Verify SSO profile was set
+            assert 'sso-profile' in result
+            assert AwsHelper.get_active_profile() == 'sso-profile'
+
+    @pytest.mark.asyncio
+    async def test_set_aws_profile_invalid(self, handler, mock_context, temp_aws_config):
+        """Test setting an invalid AWS profile."""
+        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+            with pytest.raises(Exception) as exc_info:
+                await handler.set_aws_profile(mock_context, 'nonexistent-profile')
+            
+            assert 'not found' in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_aws_profile_when_set(self, handler, mock_context):
+        """Test getting AWS profile when it's set."""
+        AwsHelper.set_active_profile('test-profile')
+        
+        result = await handler.get_aws_profile(mock_context)
+        
+        assert 'test-profile' in result
+
+    @pytest.mark.asyncio
+    async def test_get_aws_profile_when_not_set(self, handler, mock_context):
+        """Test getting AWS profile when it's not set."""
+        AwsHelper._active_profile = None
+        
+        with patch.dict(os.environ, {}, clear=True):
+            result = await handler.get_aws_profile(mock_context)
+            
+            assert 'No AWS profile' in result
+
+    @pytest.mark.asyncio
+    async def test_list_k8s_contexts(self, handler, mock_context, temp_kubeconfig):
+        """Test listing Kubernetes contexts from kubeconfig."""
+        with patch.dict(os.environ, {'KUBECONFIG': str(temp_kubeconfig)}):
+            result = await handler.list_k8s_contexts(mock_context)
+            
+            # Verify contexts were found
+            assert 'contexts' in result
+            assert 'context1' in result['contexts']
+            assert 'context2' in result['contexts']
+            assert 'eks-cluster-context' in result['contexts']
+
+    @pytest.mark.asyncio
+    async def test_list_k8s_contexts_no_config(self, handler, mock_context):
+        """Test listing Kubernetes contexts when kubeconfig doesn't exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_path = Path(temp_dir) / 'nonexistent' / 'config'
+            with patch.dict(os.environ, {'KUBECONFIG': str(fake_path)}):
+                result = await handler.list_k8s_contexts(mock_context)
+                
+                # Should return empty list
+                assert 'contexts' in result
+                assert len(result['contexts']) == 0
+
+    @pytest.mark.asyncio
+    async def test_set_k8s_context_valid(self, handler, mock_context, temp_kubeconfig):
+        """Test setting a valid Kubernetes context."""
+        with patch.dict(os.environ, {'KUBECONFIG': str(temp_kubeconfig)}):
+            result = await handler.set_k8s_context(mock_context, 'context2')
+            
+            # Verify context was set
+            assert 'context2' in result
+            
+            # Verify in K8sClientCache
+            cache = K8sClientCache()
+            assert cache.get_active_context() == 'context2'
+
+    @pytest.mark.asyncio
+    async def test_set_k8s_context_eks(self, handler, mock_context, temp_kubeconfig):
+        """Test setting an EKS Kubernetes context."""
+        with patch.dict(os.environ, {'KUBECONFIG': str(temp_kubeconfig)}):
+            result = await handler.set_k8s_context(mock_context, 'eks-cluster-context')
+            
+            # Verify EKS context was set
+            assert 'eks-cluster-context' in result
+            
+            # Verify in K8sClientCache
+            cache = K8sClientCache()
+            assert cache.get_active_context() == 'eks-cluster-context'
+
+    @pytest.mark.asyncio
+    async def test_set_k8s_context_invalid(self, handler, mock_context, temp_kubeconfig):
+        """Test setting an invalid Kubernetes context."""
+        with patch.dict(os.environ, {'KUBECONFIG': str(temp_kubeconfig)}):
+            with pytest.raises(Exception) as exc_info:
+                await handler.set_k8s_context(mock_context, 'nonexistent-context')
+            
+            assert 'not found' in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_k8s_context_when_set(self, handler, mock_context):
+        """Test getting Kubernetes context when it's set."""
+        cache = K8sClientCache()
+        cache.set_active_context('test-context')
+        
+        result = await handler.get_k8s_context(mock_context)
+        
+        assert 'test-context' in result
+
+    @pytest.mark.asyncio
+    async def test_get_k8s_context_when_not_set(self, handler, mock_context):
+        """Test getting Kubernetes context when it's not set."""
+        result = await handler.get_k8s_context(mock_context)
+        
+        assert 'No Kubernetes context' in result
+
+    @pytest.mark.asyncio
+    async def test_profile_switching_workflow(self, handler, mock_context, temp_aws_config):
+        """Test a complete workflow of switching between profiles."""
+        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+            # List profiles
+            profiles = await handler.list_aws_profiles(mock_context)
+            assert 'test-profile' in profiles['profiles']
+            
+            # Set first profile
+            await handler.set_aws_profile(mock_context, 'test-profile')
+            result = await handler.get_aws_profile(mock_context)
+            assert 'test-profile' in result
+            
+            # Switch to another profile
+            await handler.set_aws_profile(mock_context, 'another-profile')
+            result = await handler.get_aws_profile(mock_context)
+            assert 'another-profile' in result
+            
+            # Verify cache was cleared on switch
+            assert len(AwsHelper._client_cache) == 0
+
+    @pytest.mark.asyncio
+    async def test_context_switching_workflow(self, handler, mock_context, temp_kubeconfig):
+        """Test a complete workflow of switching between contexts."""
+        with patch.dict(os.environ, {'KUBECONFIG': str(temp_kubeconfig)}):
+            # List contexts
+            contexts = await handler.list_k8s_contexts(mock_context)
+            assert 'context1' in contexts['contexts']
+            
+            # Set first context
+            await handler.set_k8s_context(mock_context, 'context1')
+            result = await handler.get_k8s_context(mock_context)
+            assert 'context1' in result
+            
+            # Switch to another context
+            await handler.set_k8s_context(mock_context, 'context2')
+            result = await handler.get_k8s_context(mock_context)
+            assert 'context2' in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_profile_types(self, handler, mock_context, temp_aws_config):
+        """Test handling different types of AWS profiles (regular, SSO, credentials-only)."""
+        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+            # Test regular profile
+            await handler.set_aws_profile(mock_context, 'test-profile')
+            assert AwsHelper.get_active_profile() == 'test-profile'
+            
+            # Test SSO profile
+            await handler.set_aws_profile(mock_context, 'sso-profile')
+            assert AwsHelper.get_active_profile() == 'sso-profile'
+            
+            # Test credentials-only profile
+            await handler.set_aws_profile(mock_context, 'creds-only-profile')
+            assert AwsHelper.get_active_profile() == 'creds-only-profile'
+            
+            # Test default profile
+            await handler.set_aws_profile(mock_context, 'default')
+            assert AwsHelper.get_active_profile() == 'default'

--- a/src/eks-mcp-server/tests/test_profile_context_handler.py
+++ b/src/eks-mcp-server/tests/test_profile_context_handler.py
@@ -155,58 +155,80 @@ users:
             yield config_file
 
     @pytest.mark.asyncio
-    async def test_list_aws_profiles(self, handler, mock_context, temp_aws_config):
-        """Test listing AWS profiles from config files."""
-        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+    async def test_list_aws_profiles(self, handler, mock_context):
+        """Test listing AWS profiles from boto3 session discovery."""
+        available = ['test-profile', 'sso-profile', 'another-profile', 'creds-only-profile']
+        with patch('awslabs.eks_mcp_server.profile_context_handler.boto3.Session') as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session.available_profiles = available
+            mock_session_cls.return_value = mock_session
+
             result = await handler.list_aws_profiles(mock_context)
-            
-            # Verify profiles were found
-            assert 'profiles' in result
-            assert 'default' in result['profiles']
-            assert 'test-profile' in result['profiles']
-            assert 'sso-profile' in result['profiles']
-            assert 'another-profile' in result['profiles']
-            assert 'creds-only-profile' in result['profiles']
+
+        assert 'profiles' in result
+        returned = set(result['profiles'])
+        for profile in available:
+            assert profile in returned
+        assert 'default' in returned
 
     @pytest.mark.asyncio
     async def test_list_aws_profiles_no_config_files(self, handler, mock_context):
         """Test listing AWS profiles when config files don't exist."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            with patch.object(Path, 'home', return_value=Path(temp_dir)):
-                result = await handler.list_aws_profiles(mock_context)
-                
-                # Should return empty list
-                assert 'profiles' in result
-                assert len(result['profiles']) == 0
+        with patch('awslabs.eks_mcp_server.profile_context_handler.boto3.Session') as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session.available_profiles = []
+            mock_session_cls.return_value = mock_session
+
+            result = await handler.list_aws_profiles(mock_context)
+
+        assert result['profiles'] == ['default']
 
     @pytest.mark.asyncio
-    async def test_set_aws_profile_valid(self, handler, mock_context, temp_aws_config):
+    async def test_set_aws_profile_valid(self, handler, mock_context):
         """Test setting a valid AWS profile."""
-        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+        with patch.object(handler, '_get_aws_profiles', return_value=['test-profile']):
             result = await handler.set_aws_profile(mock_context, 'test-profile')
-            
-            # Verify profile was set
-            assert 'test-profile' in result
-            assert AwsHelper.get_active_profile() == 'test-profile'
+
+        assert 'test-profile' in result
+        assert AwsHelper.get_active_profile() == 'test-profile'
 
     @pytest.mark.asyncio
-    async def test_set_aws_profile_sso(self, handler, mock_context, temp_aws_config):
+    async def test_set_aws_profile_sso(self, handler, mock_context):
         """Test setting an AWS SSO profile."""
-        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+        with patch.object(handler, '_get_aws_profiles', return_value=['sso-profile']):
             result = await handler.set_aws_profile(mock_context, 'sso-profile')
-            
-            # Verify SSO profile was set
-            assert 'sso-profile' in result
-            assert AwsHelper.get_active_profile() == 'sso-profile'
+
+        assert 'sso-profile' in result
+        assert AwsHelper.get_active_profile() == 'sso-profile'
 
     @pytest.mark.asyncio
-    async def test_set_aws_profile_invalid(self, handler, mock_context, temp_aws_config):
+    async def test_set_aws_profile_invalid(self, handler, mock_context):
         """Test setting an invalid AWS profile."""
-        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
+        with patch.object(handler, '_get_aws_profiles', return_value=['valid-profile']):
             with pytest.raises(Exception) as exc_info:
                 await handler.set_aws_profile(mock_context, 'nonexistent-profile')
-            
-            assert 'not found' in str(exc_info.value)
+
+        assert 'not found' in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_clear_aws_profile_with_none(self, handler, mock_context):
+        """Test that providing None clears the active profile."""
+        AwsHelper.set_active_profile('existing')
+
+        result = await handler.set_aws_profile(mock_context, None)
+
+        assert 'AWS profile cleared' in result
+        assert AwsHelper.get_active_profile() is None
+
+    @pytest.mark.asyncio
+    async def test_clear_aws_profile_with_default_string(self, handler, mock_context):
+        """Test that providing 'default' clears the active profile."""
+        AwsHelper.set_active_profile('existing')
+
+        result = await handler.set_aws_profile(mock_context, 'default')
+
+        assert 'AWS profile cleared' in result
+        assert AwsHelper.get_active_profile() is None
 
     @pytest.mark.asyncio
     async def test_get_aws_profile_when_set(self, handler, mock_context):
@@ -304,25 +326,28 @@ users:
         assert 'No Kubernetes context' in result
 
     @pytest.mark.asyncio
-    async def test_profile_switching_workflow(self, handler, mock_context, temp_aws_config):
+    async def test_profile_switching_workflow(self, handler, mock_context):
         """Test a complete workflow of switching between profiles."""
-        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
-            # List profiles
+        available = ['test-profile', 'another-profile']
+        with patch('awslabs.eks_mcp_server.profile_context_handler.boto3.Session') as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session.available_profiles = available
+            mock_session_cls.return_value = mock_session
+
             profiles = await handler.list_aws_profiles(mock_context)
-            assert 'test-profile' in profiles['profiles']
-            
-            # Set first profile
+
+        assert 'test-profile' in profiles['profiles']
+
+        with patch.object(handler, '_get_aws_profiles', return_value=available):
             await handler.set_aws_profile(mock_context, 'test-profile')
             result = await handler.get_aws_profile(mock_context)
             assert 'test-profile' in result
-            
-            # Switch to another profile
+
             await handler.set_aws_profile(mock_context, 'another-profile')
             result = await handler.get_aws_profile(mock_context)
             assert 'another-profile' in result
-            
-            # Verify cache was cleared on switch
-            assert len(AwsHelper._client_cache) == 0
+
+    assert len(AwsHelper._client_cache) == 0
 
     @pytest.mark.asyncio
     async def test_context_switching_workflow(self, handler, mock_context, temp_kubeconfig):
@@ -343,21 +368,22 @@ users:
             assert 'context2' in result
 
     @pytest.mark.asyncio
-    async def test_multiple_profile_types(self, handler, mock_context, temp_aws_config):
+    async def test_multiple_profile_types(self, handler, mock_context):
         """Test handling different types of AWS profiles (regular, SSO, credentials-only)."""
-        with patch.object(Path, 'home', return_value=temp_aws_config.parent):
-            # Test regular profile
+        with patch.object(handler, '_get_aws_profiles', return_value=[
+            'test-profile',
+            'sso-profile',
+            'creds-only-profile',
+            'default',
+        ]):
             await handler.set_aws_profile(mock_context, 'test-profile')
             assert AwsHelper.get_active_profile() == 'test-profile'
-            
-            # Test SSO profile
+
             await handler.set_aws_profile(mock_context, 'sso-profile')
             assert AwsHelper.get_active_profile() == 'sso-profile'
-            
-            # Test credentials-only profile
+
             await handler.set_aws_profile(mock_context, 'creds-only-profile')
             assert AwsHelper.get_active_profile() == 'creds-only-profile'
-            
-            # Test default profile
-            await handler.set_aws_profile(mock_context, 'default')
-            assert AwsHelper.get_active_profile() == 'default'
+
+        await handler.set_aws_profile(mock_context, 'default')
+        assert AwsHelper.get_active_profile() is None


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
quick attempt at https://github.com/awslabs/mcp/issues/1404  test this at work and personally for a few days before making a PR from this fork and filling in more details.... 

//to do
trial run this for a few working days at work for cluster ops, incidents, development 

has a few issues with existing code... (wrong-profile/region client reuse)

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
